### PR TITLE
Fix: 修复单次请求携带 headers 影响全局请求 headers 的问题

### DIFF
--- a/uview-ui/libs/request/index.js
+++ b/uview-ui/libs/request/index.js
@@ -23,7 +23,7 @@ class Request {
 		options.responseType = options.responseType || this.config.responseType;
 		options.url = options.url || '';
 		options.params = options.params || {};
-		options.header = Object.assign(this.config.header, options.header);
+		options.header = Object.assign({}, this.config.header, options.header);
 		options.method = options.method || this.config.method;
 
 		return new Promise((resolve, reject) => {


### PR DESCRIPTION
原代码：

```js
options.header = Object.assign(this.config.header, options.header);
```


这会将 `options.header` 的属性值合并到 `this.config.header` 上，后续的请求都会受到影响。

---

修改后：

```js
options.header = Object.assign({}, this.config.header, options.header);
```

每次调用请求时都会将 `options.header` 和 `this.config.header` 都合并到一个空对象上，对 `this.config.header` 不产生影响。
