### PR TITLE
pref: 单独封装拼接图片地址的函数

### DIFF
--- a/uview-ui/index.js
+++ b/uview-ui/index.js
@@ -56,6 +56,8 @@ import random from './libs/function/random.js'
 import trim from './libs/function/trim.js'
 // toast提示，对uni.showToast的封装
 import toast from './libs/function/toast.js'
+// 拼接图片地址
+import getImgPath from './libs/function/getImgPath.js'
 // 获取父组件参数
 import getParent from './libs/function/getParent.js'
 // 获取整个父组件
@@ -99,6 +101,7 @@ const $u = {
 	random,
 	deepClone,
 	deepMerge,
+	getImgPath,
 	getParent,
 	$parent,
 	addUnit,

--- a/uview-ui/libs/function/getImgPath.js
+++ b/uview-ui/libs/function/getImgPath.js
@@ -1,0 +1,10 @@
+import config from "@/common/config.js"
+
+/**
+ * 拼接图片地址
+ * @param {String} idFile 
+ * @returns {String} 完整的图片地址
+ */
+export default function getImgPath (idFile) {
+  return `${config.baseApi}/file/getImgStream?idFile=${idFile}`
+}


### PR DESCRIPTION
单独封装拼接图片地址的函数，并将其挂载到 this.$u 上方便在组件中直接调用


1. 在组件的 js 中使用：

```js
this.$u.getImgPath('idFile')
```

2. 在组件的 template 中使用

```html
<u-image :src="$u.getImgPath('idFile')"></u-image>
```