### PR TITLE
Fix: 修复订单列表订单项中间 content 区域宽度,使其撑开所有剩余空间

### DIFF
--- a/pages/order/list.vue
+++ b/pages/order/list.vue
@@ -458,6 +458,8 @@
 			}
 
 			.content {
+				flex: 1;
+				
 				.title {
 					font-size: 28rpx;
 					line-height: 50rpx;


### PR DESCRIPTION
增加 css 代码，使订单的 `.content` 部分占据所有剩余空间。

```css
.content {
    flex: 1;
}
```

效果如下：

![订单项中间 content 区域宽度](https://user-images.githubusercontent.com/34718241/119619803-f0a83900-be36-11eb-856d-4883be5e257a.png)
