### PR TITLE
pref: 优化商品详情页面底部样式

### DIFF
--- a/pages/goods/goods.vue
+++ b/pages/goods/goods.vue
@@ -1,5 +1,5 @@
 <template>
-	<view>
+	<view class="goods-detail-wrapper">
 		<u-swiper :list="goods.thumb" height="800"></u-swiper>
 		<view class="content">
 			<view class="title">{{ goods.name }}</view>
@@ -331,6 +331,9 @@
 
 
 <style lang="scss" scoped>
+	.goods-detail-wrapper {
+		padding-bottom: 140rpx;
+	}
 	.content {
 		padding: 30rpx;
 


### PR DESCRIPTION
商品详情页面底部 fixed 定位了一栏操作按钮，所以外层容器应该设置一个 padding-bottom 避免页面内容被遮挡住。

效果如下：

![WeChatd101315010e02810f9c588537e4b4725](https://user-images.githubusercontent.com/34718241/119621850-2e0dc600-be39-11eb-9d9b-3e1da932bc14.png)
